### PR TITLE
Avoid loading all the mappings

### DIFF
--- a/src/CreativeSoftworks/BehatWiremockContextExtension/Mappings/MappingsService.php
+++ b/src/CreativeSoftworks/BehatWiremockContextExtension/Mappings/MappingsService.php
@@ -6,7 +6,7 @@ use Guzzle\Http\Client;
 
 class MappingsService
 {
-    const WIREMOCK_RESET_PATH = '/__admin/mappings/reset';
+    const WIREMOCK_RESET_PATH = '/__admin/reset';
     const WIREMOCK_NEW_MAPPING_PATH = '/__admin/mappings/new';
     
     /**


### PR DESCRIPTION
Updated MappingsService to reset Wiremock altogether, and avoid loading default mappings.

This way we doesn't pollute the mappings with a huge number of - sometimes conflicting - rules, and thus reduce the possibility that an unwanted mapping ends up catching our request. (As requesting something else with an otherwise valid request from an API is also an error we should catch.)
