### PR TITLE
Avoid loading default Wiremock mappings

### DIFF
--- a/spec/CreativeSoftworks/BehatWiremockContextExtension/Mappings/MappingsServiceSpec.php
+++ b/spec/CreativeSoftworks/BehatWiremockContextExtension/Mappings/MappingsServiceSpec.php
@@ -30,7 +30,7 @@ class MappingsServiceSpec extends ObjectBehavior
     
     function it_resets_wiremock_mappings(Client $client, Response $response)
     {
-        $client->post('base_url/__admin/mappings/reset')->shouldBeCalled()->willReturn($client);
+        $client->post('base_url/__admin/reset')->shouldBeCalled()->willReturn($client);
         $client->send()->shouldBeCalled()->willReturn($response);
         
         $this->resetMappings();

--- a/src/CreativeSoftworks/BehatWiremockContextExtension/Mappings/MappingsService.php
+++ b/src/CreativeSoftworks/BehatWiremockContextExtension/Mappings/MappingsService.php
@@ -6,7 +6,7 @@ use Guzzle\Http\Client;
 
 class MappingsService
 {
-    const WIREMOCK_RESET_PATH = '/__admin/mappings/reset';
+    const WIREMOCK_RESET_PATH = '/__admin/reset';
     const WIREMOCK_NEW_MAPPING_PATH = '/__admin/mappings/new';
     
     /**


### PR DESCRIPTION
Changed MappingsService, so it resets Wiremock atogether. This way we can avoid
polluting mappings, and catching the request by an unwanted one. (As requesting
something else is also a bug.)
